### PR TITLE
Verify that generated keypair correctly signs and verifies message

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "compile-with-source-maps": "babel --optional runtime -s -t -d distrib/npm/ src/",
     "prepublish": "npm test && npm run lint && npm run compile",
     "test": "istanbul test _mocha",
-     "codecov": "cat ./coverage/coverage.json | ./node_modules/codecov.io/bin/codecov.io.js",
+    "codecov": "cat ./coverage/coverage.json | ./node_modules/codecov.io/bin/codecov.io.js",
     "lint": "if ! [ -f eslintrc ]; then curl -o eslintrc 'https://raw.githubusercontent.com/ripple/javascript-style-guide/es6/eslintrc'; echo 'parser: babel-eslint' >> eslintrc; fi; eslint -c eslintrc src/*.js test/*.js"
   },
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -75,13 +75,11 @@ function deriveKeypair(seed, options) {
   const algorithm = decoded.type === 'ed25519' ? 'ed25519' : 'ecdsa-secp256k1'
   const method = select(algorithm)
   const keypair = method.deriveKeypair(decoded.bytes, options)
-  const goodMessage = hash('This test message should verify.')
-  const badMessage = hash('This test message should NOT verify.')
-  const goodSignature = method.sign(goodMessage, keypair.privateKey)
-  if (method.verify(goodMessage, goodSignature, keypair.publicKey) !== true ||
-      method.verify(badMessage, goodSignature, keypair.publicKey) !== false) {
-        throw new Error('derived keypair did not generate verifiable signatures');
-      }
+  const messageToVerify = hash('This test message should verify.')
+  const signature = method.sign(messageToVerify, keypair.privateKey)
+  if (method.verify(messageToVerify, signature, keypair.publicKey) !== true) {
+    throw new Error('derived keypair did not generate verifiable signature');
+  }
   return keypair
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,16 @@ function select(algorithm) {
 function deriveKeypair(seed, options) {
   const decoded = addressCodec.decodeSeed(seed)
   const algorithm = decoded.type === 'ed25519' ? 'ed25519' : 'ecdsa-secp256k1'
-  return select(algorithm).deriveKeypair(decoded.bytes, options)
+  const method = select(algorithm)
+  const keypair = method.deriveKeypair(decoded.bytes, options)
+  const goodMessage = hash('This test message should verify.')
+  const badMessage = hash('This test message should NOT verify.')
+  const goodSignature = method.sign(goodMessage, keypair.privateKey)
+  if (method.verify(goodMessage, goodSignature, keypair.publicKey) !== true ||
+      method.verify(badMessage, goodSignature, keypair.publicKey) !== false) {
+        throw new Error('derived keypair did not generate verifiable signatures');
+      }
+  return keypair
 }
 
 function getAlgorithmFromKey(key) {


### PR DESCRIPTION
Add a check in `deriveKeypair` to ensure that it always returns good keypairs.

1. Sign a message.
2. Verify the signature.
3. Verify that the signature is not valid for a different message.