### PR TITLE
Add declarations option to tsconfig

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,7 @@ function deriveNodeAddress(publicKey) {
 
 const decodeSeed = addressCodec.decodeSeed
 
-module.exports = {
+export default {
   generateSeed,
   deriveKeypair,
   sign,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ const Secp256k1 = elliptic.ec('secp256k1')
 const hexToBytes = utils.hexToBytes
 const bytesToHex = utils.bytesToHex
 
-function generateSeed(options: {
+export function generateSeed(options: {
   entropy?: Uint8Array,
   algorithm?: 'ed25519' | 'secp256k1'
 } = {}) {
@@ -72,7 +72,7 @@ function select(algorithm) {
   return methods[algorithm]
 }
 
-function deriveKeypair(seed, options) {
+export function deriveKeypair(seed, options) {
   const decoded = addressCodec.decodeSeed(seed)
   const algorithm = decoded.type === 'ed25519' ? 'ed25519' : 'ecdsa-secp256k1'
   const method = select(algorithm)
@@ -91,12 +91,12 @@ function getAlgorithmFromKey(key) {
     'ed25519' : 'ecdsa-secp256k1'
 }
 
-function sign(messageHex, privateKey) {
+export function sign(messageHex, privateKey) {
   const algorithm = getAlgorithmFromKey(privateKey)
   return select(algorithm).sign(hexToBytes(messageHex), privateKey)
 }
 
-function verify(messageHex, signature, publicKey) {
+export function verify(messageHex, signature, publicKey) {
   const algorithm = getAlgorithmFromKey(publicKey)
   return select(algorithm).verify(hexToBytes(messageHex), signature, publicKey)
 }
@@ -106,24 +106,14 @@ function deriveAddressFromBytes(publicKeyBytes: Buffer) {
     utils.computePublicKeyHash(publicKeyBytes))
 }
 
-function deriveAddress(publicKey) {
+export function deriveAddress(publicKey) {
   return deriveAddressFromBytes(hexToBytes(publicKey))
 }
 
-function deriveNodeAddress(publicKey) {
+export function deriveNodeAddress(publicKey) {
   const generatorBytes = addressCodec.decodeNodePublic(publicKey)
   const accountPublicBytes = accountPublicFromPublicGenerator(generatorBytes)
   return deriveAddressFromBytes(accountPublicBytes)
 }
 
-const decodeSeed = addressCodec.decodeSeed
-
-export default {
-  generateSeed,
-  deriveKeypair,
-  sign,
-  verify,
-  deriveAddress,
-  deriveNodeAddress,
-  decodeSeed
-}
+export const decodeSeed = addressCodec.decodeSeed

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "suppressImplicitAnyIndexErrors": false,
     "sourceMap": true,
     "skipLibCheck": true,
-    "allowJs": true
+    "allowJs": true,
+    "declaration": true
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
This PR adds the typescript declarations into the dist folder.

It would be nice to have declarations in the NPM releases

The motivation for doing this comes from using ripple-lib which has this as a dependency and my with my strict tsconfig I get errors when running my `tsc --build`

```
node_modules/ripple-lib/dist/npm/offline/derive.d.ts:1:46 - error TS7016: Could not find a declaration file for module 'ripple-keypairs'. '/Users/tstorm/Projects/xpring-wallet-system/interface/node_modules/ripple-keypairs/distrib/npm/index.js' implicitly has an 'any' type.
  Try `npm install @types/ripple-keypairs` if it exists or add a new declaration (.d.ts) file containing `declare module 'ripple-keypairs';`

1 import { deriveKeypair, deriveAddress } from 'ripple-keypairs';
```