### PR TITLE
Update TSConfig to produce type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
     "type": "git",
     "url": "git://github.com/ripple/ripple-keypairs.git"
   },
-  "license": "ISC"
+  "license": "ISC",
+  "engines": {
+    "node": ">= 8"
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,31 @@
 {
   "compilerOptions": {
-    "target": "es6",
-    "lib": [
-      "es2017"
-    ],
+    // Basic Options
+    "target": "ES2017",
+    "module": "commonjs",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+
+    // Directories
     "outDir": "dist",
     "rootDir": "src",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "strictNullChecks": false,
+
+    // Strict Type-Checking Options
+    "strict": true,
     "noImplicitAny": false,
+
+    // Additional Checks
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "removeComments": false,
-    "preserveConstEnums": false,
-    "suppressImplicitAnyIndexErrors": false,
-    "sourceMap": true,
-    "skipLibCheck": true,
-    "allowJs": true
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+
+    // Module Resolution Options
+    "moduleResolution": "node",
+
+    // Advanced Options
+    "forceConsistentCasingInFileNames": true
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     // Basic Options
-    "target": "ES2017",
+    "target": "ES6",
     "module": "commonjs",
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
Also, add some stricter type-checking, and remove settings that were set to the same value as the default for that setting.

I also reorganized the sections into the sections that TypeScript itself generates when you boot up a `tsconfig.json` using their CLI.