### PR TITLE
Skip coverage for untestable code

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,7 @@ function deriveKeypair(seed, options) {
   const keypair = method.deriveKeypair(decoded.bytes, options)
   const messageToVerify = hash('This test message should verify.')
   const signature = method.sign(messageToVerify, keypair.privateKey)
+  /* istanbul ignore if */
   if (method.verify(messageToVerify, signature, keypair.publicKey) !== true) {
     throw new Error('derived keypair did not generate verifiable signature')
   }

--- a/src/secp256k1.ts
+++ b/src/secp256k1.ts
@@ -15,10 +15,12 @@ function deriveScalar(bytes, discrim?: number) {
     }
     hasher.addU32(i)
     const key = hasher.first256BN()
+    /* istanbul ignore else */
     if (key.cmpn(0) > 0 && key.cmp(order) < 0) {
       return key
     }
   }
+  /* istanbul ignore next */
   throw new Error('impossible unicorn ;)')
 }
 


### PR DESCRIPTION
This way we can get to 100% code coverage. 100% coverage is great because it gives a clear indicator when there has been a coverage regression, and it makes explicit which code you are choosing not to test (through inline coverage disable comments) rather than implicit(in lower percentages of coverage in the report).

This PR would get us to 100% coverage once https://github.com/ripple/ripple-keypairs/pull/82 is merged.