### PR TITLE
Drop support for Node.js version 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-  - 8
   - 10
   - 12
   - 13
+  - 14
 script:
   - yarn compile
   - yarn lint

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
   },
   "license": "ISC",
   "engines": {
-    "node": ">= 8"
+    "node": ">= 10"
   }
 }


### PR DESCRIPTION
Node.js 8 reached End-of-Life on 31st December 2019. If you are still using Node.js 8, we recommend upgrading to version 10 or higher as soon as possible.

https://nodejs.org/en/about/releases/